### PR TITLE
Update traverse to 0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test" : "tap test/*.js"
     },
     "dependencies" : {
-        "traverse" : "~0.5.1",
+        "traverse" : "~0.6.6",
         "uglify-js" : "~1.1.1"
     },
     "devDependencies" : {


### PR DESCRIPTION
traverse 0.5.x is older than 2012...
Everyone else use 0.6.6 !

Thanks !

@substack note that this module is indirectly used by official [googleapis module](https://www.npmjs.com/package/googleapis) !

```
googleapis/node_modules/gapitoken/node_modules/jws/node_modules/tap/node_modules/runforcover/node_modules/bunker/node_modules/burrito/node_modules/traverse
```
